### PR TITLE
Implement Screen capturing

### DIFF
--- a/isototest/Cargo.toml
+++ b/isototest/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/ByteOtter/isotest-ng/tree/main/isototest"
 license = "GPL-2.0"
 
 [dependencies]
+image = "0.25.2"
 tokio = "1.38.1"
 vnc-rs = "0.5.1"
 

--- a/isototest/src/action.rs
+++ b/isototest/src/action.rs
@@ -68,12 +68,6 @@ pub async fn write_to_console(
     Ok(())
 }
 
-#[allow(unused)]
-/// Receive a screenshot of the remote machine.
-pub async fn read_screen(client: &VncClient) -> Result<(), VncError> {
-    todo!("Not implemented yet!")
-}
-
 /// Encapsulate the `client.input()` function calls to avoid repitition.
 ///
 /// Press and release a button or release it manually, if it is pressed.

--- a/isototest/src/connection.rs
+++ b/isototest/src/connection.rs
@@ -49,8 +49,11 @@ pub async fn create_vnc_client(
         .add_encoding(vnc::VncEncoding::Zrle)
         .add_encoding(vnc::VncEncoding::CopyRect)
         .add_encoding(vnc::VncEncoding::Raw)
+        .add_encoding(vnc::VncEncoding::Trle)
+        .add_encoding(vnc::VncEncoding::CursorPseudo)
+        .add_encoding(vnc::VncEncoding::DesktopSizePseudo)
         .allow_shared(true)
-        .set_pixel_format(PixelFormat::bgra())
+        .set_pixel_format(PixelFormat::rgba())
         .build()?
         .try_start()
         .await?

--- a/isototest/src/connection.rs
+++ b/isototest/src/connection.rs
@@ -53,6 +53,8 @@ pub async fn create_vnc_client(
         .add_encoding(vnc::VncEncoding::CursorPseudo)
         .add_encoding(vnc::VncEncoding::DesktopSizePseudo)
         .allow_shared(true)
+        // NOTE: If the color encoding is changed in the following line, you must also change it in
+        // view.rs to avoid the saved screenshots from having swapped colors.
         .set_pixel_format(PixelFormat::rgba())
         .build()?
         .try_start()

--- a/isototest/src/lib.rs
+++ b/isototest/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod action;
 pub mod connection;
 mod types;
+pub mod view;

--- a/isototest/src/view.rs
+++ b/isototest/src/view.rs
@@ -1,0 +1,109 @@
+use image::{GenericImage, ImageFormat, Rgba};
+use std::{
+    path::Path,
+    time::{Duration, Instant},
+};
+
+use image::ImageBuffer;
+
+use image::DynamicImage::ImageRgba8;
+use vnc::{Rect, VncClient, VncError, VncEvent, X11Event};
+
+/// Receive a screenshot of the remote machine.
+pub async fn read_screen(
+    client: &VncClient,
+    file_path: &str,
+    resolution: Option<(u32, u32)>,
+    timeout: Duration,
+) -> Result<(u32, u32), VncError> {
+    // Request screen update
+    client.input(X11Event::Refresh).await?;
+
+    let mut img_parts: Vec<(Rect, Vec<u8>)> = Vec::new();
+    let mut width;
+    let mut height;
+    match resolution {
+        Some((x, y)) => {
+            width = Some(x);
+            height = Some(y);
+        }
+        None => match client.recv_event().await? {
+            VncEvent::SetResolution(screen) => {
+                println!("Screen resolution: {}x{}", screen.width, screen.height);
+                width = Some(screen.width as u32);
+                height = Some(screen.height as u32);
+
+                client.input(X11Event::Refresh).await?;
+            }
+            _ => {
+                return Err(VncError::General(
+                    "[error] No resolution found!".to_string(),
+                ))
+            }
+        },
+    }
+    let path: &Path = Path::new(file_path);
+
+    let idle_timer = Instant::now();
+
+    loop {
+        match client.poll_event().await? {
+            Some(x) => match x {
+                VncEvent::SetResolution(screen) => {
+                    println!("Screen resolution: {}x{}", screen.width, screen.height);
+                    width = Some(screen.width as u32);
+                    height = Some(screen.height as u32);
+
+                    client.input(X11Event::Refresh).await?;
+                }
+                VncEvent::RawImage(rect, data) => {
+                    img_parts.push((rect, data));
+                }
+                VncEvent::Error(e) => {
+                    eprintln!("[error] {}", e);
+                    break;
+                }
+                x => {
+                    println!("{:?}", x);
+                    break;
+                }
+            },
+            None => {
+                if idle_timer.elapsed() >= timeout {
+                    break;
+                }
+            }
+        }
+    }
+    let mut image: ImageBuffer<Rgba<u8>, _> = ImageBuffer::new(width.unwrap(), height.unwrap());
+
+    // Reconstruct image.
+    for (rect, data) in img_parts {
+        let mut view = image.sub_image(
+            rect.x as u32,
+            rect.y as u32,
+            rect.width as u32,
+            rect.height as u32,
+        );
+        let image_buffer: ImageBuffer<Rgba<u8>, _> =
+            ImageBuffer::from_raw(rect.width as u32, rect.height as u32, data.to_vec())
+                .ok_or("Failed to create image buffer!")
+                .unwrap();
+
+        for x in 0..rect.width {
+            for y in 0..rect.height {
+                view.put_pixel(
+                    x as u32,
+                    y as u32,
+                    image_buffer.get_pixel(x as u32, y as u32).to_owned(),
+                );
+            }
+        }
+    }
+    ImageRgba8(image)
+        .save_with_format(path, ImageFormat::Png)
+        .unwrap();
+
+    println!("Screenshot saved to {}", file_path);
+    Ok((width.unwrap(), height.unwrap()))
+}


### PR DESCRIPTION
# What?

Implement logic to capture screenshots of the remote machine.

## Todo:
- [ ] Currently, due to how VNC works, subsequent calls of the `read_screen` function only return the delta between the current and the previous view. This has to change to include a full picture.
- [x] Document code
- [x] Improve Error handling
- [x] Remove/Change print calls
- [x] Fix clippy warnings
- [x] Add static type annotations